### PR TITLE
feat: ensure revision is an int

### DIFF
--- a/app/[slug]/[revision]/page.js
+++ b/app/[slug]/[revision]/page.js
@@ -18,7 +18,7 @@ const getPageData = cache(async (slug, revision) => {
   const pages = await pagesCollection()
 
   const pageData = await pages.findOne({
-    slug, revision: parseInt(revision) || 1
+    slug, revision: parseInt(revision)
   })
 
   const revisions = await pages.find({

--- a/app/[slug]/page.js
+++ b/app/[slug]/page.js
@@ -18,7 +18,7 @@ const getPageData = cache(async (slug, revision) => {
   const pages = await pagesCollection()
 
   const pageData = await pages.findOne({
-    slug, revision: parseInt(revision) || 1
+    slug, revision
   })
 
   const revisions = await pages.find({
@@ -55,13 +55,6 @@ export async function generateMetadata({ params }) {
 export default async function Slug({ params }) {
   const { slug } = params
   const revision = 1
-
-  /**
-   * Redirect revision 1 so we don't have a duplicate URL
-   */
-  // if (revision === '1') {
-  //   redirect(`/${slug}`)
-  // }
 
   const { pageData, revisions } = await getPageData(slug, revision)
 


### PR DESCRIPTION
To avoid googlebot from crawling urls such as:

https://jsperf.app/index/lock.php