### PR TITLE
fix: sitemaps aggregate

### DIFF
--- a/app/sitemap/[year]/route.js
+++ b/app/sitemap/[year]/route.js
@@ -24,6 +24,9 @@ export async function GET(
       }
     },
     {
+      '$sort': { revision: 1 }
+    }
+    {
       '$group': {
         _id: "$slug",
         revision: {

--- a/app/sitemap/[year]/route.js
+++ b/app/sitemap/[year]/route.js
@@ -25,7 +25,7 @@ export async function GET(
     },
     {
       '$sort': { revision: 1 }
-    }
+    },
     {
       '$group': {
         _id: "$slug",

--- a/app/sitemap/[year]/route.js
+++ b/app/sitemap/[year]/route.js
@@ -24,21 +24,14 @@ export async function GET(
       }
     },
     {
-      '$sort': {
-        'revision': 1
-      }
-    },
-    {
       '$group': {
         _id: "$slug",
-        document: {
-          "$last": "$$ROOT"
+        revision: {
+          '$max': '$revision'
+        },
+        published: {
+          $last: '$published'
         }
-      }
-    },
-    {
-      '$replaceRoot': {
-        newRoot: "$document"
       }
     },
     {
@@ -67,7 +60,7 @@ export async function GET(
 
   const xmlResponse = `<?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    ${result.map(({slug, revision, published}) => {
+    ${result.map(({_id: slug, revision, published}) => {
       return `
         <url>
           <loc>https://jsperf.app/${slug}${revision === 1 ? '' : `/${revision}`}</loc>


### PR DESCRIPTION
Fix for aggregate query timeout:

```
⨯ MongoServerError: PlanExecutor error during aggregation :: caused by :: Exceeded memory limit for $group, but didn't allow external spilling; pass allowDiskUse:true to opt in
    at Connection.onMessage (/var/task/node_modules/mongodb/lib/cmap/connection.js:202:26)
    at MessageStream.<anonymous> (/var/task/node_modules/mongodb/lib/cmap/connection.js:61:60)
    at MessageStream.emit (node:events:517:28)
    at processIncomingData (/var/task/node_modules/mongodb/lib/cmap/message_stream.js:124:16)
    at MessageStream._write (/var/task/node_modules/mongodb/lib/cmap/message_stream.js:33:9)
    at writeOrBuffer (node:internal/streams/writable:392:12)
    at _write (node:internal/streams/writable:333:10)
    at Writable.write (node:internal/streams/writable:337:10)
    at TLSSocket.ondata (node:internal/streams/readable:809:22)
    at TLSSocket.emit (node:events:517:28) {
  ok: 0,
  code: 292,
  codeName: 'QueryExceededMemoryLimitNoDiskUseAllowed',
  '$clusterTime': {
    clusterTime: new Timestamp({ t: 1747340516, i: 15 }),
    signature: {
      hash: Binary.createFromBase64('Rmq8gRmcIJw+Fsm43ZUaru1TkTc=', 0),
      keyId: new Long('7470276346380288013')
    }
  },
  operationTime: new Timestamp({ t: 1747340516, i: 15 }),
  [Symbol(errorLabels)]: Set(0) {}
}
```